### PR TITLE
Add JSON asset metadata and grid-based drawing

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -1,0 +1,22 @@
+[
+  {"image": "icons/Creatures/SVG/Abomination.svg", "title": "Abomination", "dimensions": "1x1"},
+  {"image": "icons/Creatures/SVG/DreadWarrior.svg", "title": "Dread Warrior", "dimensions": "1x1"},
+  {"image": "icons/Creatures/SVG/Gargoyle.svg", "title": "Gargoyle", "dimensions": "1x1"},
+  {"image": "icons/Creatures/SVG/Goblin.svg", "title": "Goblin", "dimensions": "1x1"},
+  {"image": "icons/Creatures/SVG/Mummy.svg", "title": "Mummy", "dimensions": "1x1"},
+  {"image": "icons/Creatures/SVG/Orc.svg", "title": "Orc", "dimensions": "1x1"},
+  {"image": "icons/Creatures/SVG/Zombie.svg", "title": "Zombie", "dimensions": "1x1"},
+  {"image": "icons/Furniture/SVG/AlchemistsBench.svg", "title": "Alchemists Bench", "dimensions": "1x1"},
+  {"image": "icons/Furniture/SVG/Bookshelf.svg", "title": "Bookshelf", "dimensions": "1x1"},
+  {"image": "icons/Furniture/SVG/Chest.svg", "title": "Chest", "dimensions": "1x1"},
+  {"image": "icons/Furniture/SVG/Rack.svg", "title": "Rack", "dimensions": "1x1"},
+  {"image": "icons/Furniture/SVG/SorcerersTable.svg", "title": "Sorcerers Table", "dimensions": "1x1"},
+  {"image": "icons/Furniture/SVG/Table.svg", "title": "Table", "dimensions": "1x1"},
+  {"image": "icons/Furniture/SVG/WeaponsRack.svg", "title": "Weapons Rack", "dimensions": "1x1"},
+  {"image": "icons/Tiles/SVG/BlockedWall_Double.svg", "title": "Blocked Wall Double", "dimensions": "2x1"},
+  {"image": "icons/Tiles/SVG/BlockedWall_Single.svg", "title": "Blocked Wall Single", "dimensions": "1x1"},
+  {"image": "icons/Tiles/SVG/Door.svg", "title": "Door", "dimensions": "1x1"},
+  {"image": "icons/Tiles/SVG/SecretDoor.svg", "title": "Secret Door", "dimensions": "1x1"},
+  {"image": "icons/Tiles/SVG/Staircase.svg", "title": "Staircase", "dimensions": "1x1"},
+  {"image": "icons/Traps/SVG/TrapPit.svg", "title": "Trap Pit", "dimensions": "1x1"}
+]

--- a/index.php
+++ b/index.php
@@ -1,7 +1,20 @@
 <?php
 
-$categories = array_filter(glob('icons/*'), 'is_dir');
+// Load asset definitions from JSON
+$assets = json_decode(file_get_contents('assets.json'), true);
 $iconIndex = 1;
+
+// Group assets by category derived from file path
+$categories = [];
+foreach ($assets as $asset) {
+    $parts = explode('/', $asset['image']);
+    $category = $parts[1] ?? 'Other';
+    if (!isset($categories[$category])) {
+        $categories[$category] = [];
+    }
+    $categories[$category][] = $asset;
+}
+ksort($categories);
 
 ?>
 
@@ -27,33 +40,30 @@ $iconIndex = 1;
             <label for="snapToGrid">Snap to Grid</label>
             <br><br>
             <div class="accordion" id="iconAccordion">
-				<?php
-				foreach ($categories as $cat) {
-					$category = basename($cat);
-					$files = glob("$cat/SVG/*.svg");
-					sort($files);
-					$catId = strtolower($category);
-					?>
+                                <?php
+                                foreach ($categories as $category => $files) {
+                                        $catId = strtolower($category);
+                                        ?>
                     <div class="accordion-item">
                         <h2 class="accordion-header" id="heading<?= $catId ?>">
                             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<?= $catId ?>" aria-expanded="false" aria-controls="collapse<?= $catId ?>">
-								<?= htmlspecialchars($category) ?>
+                                                                <?= htmlspecialchars($category) ?>
                             </button>
                         </h2>
                         <div id="collapse<?= $catId ?>" class="accordion-collapse collapse" aria-labelledby="heading<?= $catId ?>" data-bs-parent="#iconAccordion">
                             <div class="accordion-body">
-								<?php
-								foreach ($files as $file) {
-									$id = 'img' . $iconIndex++;
-									?>
-                                    <img draggable="true" ondragstart="onDragStart(event);" id="<?= $id ?>" class="artifact" width="33" src="<?= $file ?>">
-									<?php
-								}
-								?>
+                                                                <?php
+                                                                foreach ($files as $file) {
+                                                                        $id = 'img' . $iconIndex++;
+                                                                        ?>
+                                    <img draggable="true" ondragstart="onDragStart(event);" id="<?= $id ?>" class="artifact" width="33" data-dim="<?= $file['dimensions'] ?>" src="<?= $file['image'] ?>" title="<?= htmlspecialchars($file['title']) ?>">
+                                                                        <?php
+                                                                }
+                                                                ?>
                             </div>
                         </div>
                     </div>
-					<?php
+                                        <?php
 				}
 				?>
             </div>

--- a/map.js
+++ b/map.js
@@ -52,10 +52,11 @@ class Grid {
 		}
 	}
 
-	createArtifact( imageId, x, y ) {
-		// get dimensions of image - add 1 to fix remnant line of image
-		const w = ( document.getElementById( imageId ).width * window.devicePixelRatio ) + 1;
-		const h = ( document.getElementById( imageId ).height * window.devicePixelRatio ) + 1;
+        createArtifact( imageId, x, y ) {
+                const imgElem = document.getElementById( imageId );
+                const dims = imgElem.dataset.dim.split( 'x' );
+                const w = ( this.tileSize * parseInt( dims[0] ) ) + 1;
+                const h = ( this.tileSize * parseInt( dims[1] ) ) + 1;
 
 		// use coords and dimensions to copy data for what is under the artifact
 		const underlay = this.ctx.getImageData( x, y, w, h );
@@ -183,13 +184,15 @@ class Grid {
 	onDrop( e ) {
 		e.preventDefault();
 
-		const imageId = e.dataTransfer.getData( 'image' );
-		let coords;
+                const imageId = e.dataTransfer.getData( 'image' );
+                const imgElem = document.getElementById( imageId );
+                const dims = imgElem.dataset.dim.split( 'x' ).map( d => parseInt( d ) );
+                let coords;
 		
 		if ( this.snapToGrid ) {
 			// snap to grid
-			coords = this.getTileCoords( e );
-			this.ctx.clearRect( coords.x, coords.y, this.tileSize - 2, this.tileSize - 2 );
+                        coords = this.getTileCoords( e );
+                        this.ctx.clearRect( coords.x, coords.y, this.tileSize * dims[0] - 2, this.tileSize * dims[1] - 2 );
 		} else {
 			coords = this.getCursorCoords( e );
 			// image offset
@@ -197,20 +200,17 @@ class Grid {
 			coords.y = coords.y - ( e.dataTransfer.getData( 'grabbedY' ) * window.devicePixelRatio );
 		}
 
-		// create the artifact
-		this.createArtifact( imageId, coords.x, coords.y );
+                // create the artifact
+                this.createArtifact( imageId, coords.x, coords.y );
 
-		const img = document.getElementById( imageId );
-		
-
-		// drawImage at the drop point using the dropped image
-		this.ctx.drawImage(
-			img,
-			coords.x,
-			coords.y,
-			img.width * window.devicePixelRatio,
-			img.height * window.devicePixelRatio
-		);
+                // drawImage at the drop point using the dropped image
+                this.ctx.drawImage(
+                        imgElem,
+                        coords.x,
+                        coords.y,
+                        this.tileSize * dims[0],
+                        this.tileSize * dims[1]
+                );
 		e.dataTransfer.clearData();
 	}
 

--- a/map.js
+++ b/map.js
@@ -203,15 +203,23 @@ class Grid {
                 // create the artifact
                 this.createArtifact( imageId, coords.x, coords.y );
 
-                // drawImage at the drop point using the dropped image
-                this.ctx.drawImage(
-                        imgElem,
-                        coords.x,
-                        coords.y,
-                        this.tileSize * dims[0],
-                        this.tileSize * dims[1]
-                );
-		e.dataTransfer.clearData();
+                // determine natural aspect ratio in device pixels
+                let natW = imgElem.naturalWidth || imgElem.width;
+                let natH = imgElem.naturalHeight || imgElem.height;
+                natW *= window.devicePixelRatio;
+                natH *= window.devicePixelRatio;
+
+                const boundW = this.tileSize * dims[0];
+                const boundH = this.tileSize * dims[1];
+                const scale = Math.min( boundW / natW, boundH / natH );
+                const drawW = natW * scale;
+                const drawH = natH * scale;
+                const offsetX = coords.x + ( boundW - drawW ) / 2;
+                const offsetY = coords.y + ( boundH - drawH ) / 2;
+
+                // drawImage at the drop point using scaled dimensions
+                this.ctx.drawImage( imgElem, offsetX, offsetY, drawW, drawH );
+                e.dataTransfer.clearData();
 	}
 
 	onMouseDown( e ) {


### PR DESCRIPTION
## Summary
- add `assets.json` with metadata for all icon assets
- update `index.php` to build the palette from `assets.json`
- embed asset dimensions in each image and draw them using tile-based sizes in `map.js`

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_687efbfb7ad08329947e20bdfe3552a2